### PR TITLE
Fixed strdup and free usage

### DIFF
--- a/clove.h
+++ b/clove.h
@@ -20,18 +20,9 @@
 
 // wrapper for Microsoft API
 #ifndef _WIN32
-char *strtok_s(char *str, const char *delimiters, char **context) {
-    return strtok_r(str, delimiters, context);
-}  
-
-int strncpy_s(char *strDest, size_t numberOfElements, const char *strSource, size_t count) {
-    return strncpy(strDest, strSource, count) == NULL;
-}
-
-int strcpy_s(char *dest, size_t dest_size, const char *src) {
-    return strcpy(dest, src) == NULL;
-}
-
+#define strtok_s(str, delimiters, context) strtok_r(str, delimiters, context)
+#define strncpy_s(strDest, numberOfElements, strSource, count) strncpy(strDest, strSource, count) == NULL
+#define strcpy_s(dest, dest_size, src) strcpy(dest, src) == NULL
 #define _strdup strdup
 #endif
 

--- a/clove.h
+++ b/clove.h
@@ -304,7 +304,6 @@ static void __clove_exec_suite(__clove_suite_t *suite, int test_counter, unsigne
 
         char result[__CLOVE_STRING_LENGTH], strToPad[__CLOVE_TEST_ENTRY_LENGTH];
         snprintf(strToPad, __CLOVE_TEST_ENTRY_LENGTH, "%d) %s.%s", test_counter+i, suite->name, each_test->name);
-	free(each_test->name); // we can safely free here
         __clove_pad_right(result, strToPad);
 
         switch(each_test->result) {
@@ -497,7 +496,7 @@ void title(__clove_suite_t *_this_suite) { \
 #define CLOVE_SUITE_TEARDOWN(funct) _this_suite->teardown_funct = funct;
 #define CLOVE_SUITE_TESTS(...) \
     static void (*func_ptr[])(__clove_test*) = {__VA_ARGS__};\
-    char* functs_as_str = _strdup(#__VA_ARGS__);\
+    static char functs_as_str[] = #__VA_ARGS__;\
     int test_count = sizeof(func_ptr) / sizeof(func_ptr[0]);\
     _this_suite->name = name;\
     _this_suite->test_count = test_count;\
@@ -507,10 +506,9 @@ void title(__clove_suite_t *_this_suite) { \
         char *token;\
         if (i==0) { token = strtok_s(functs_as_str, ", ", &context); }\
         else { token = strtok_s(NULL, ", ", &context); }\
-        _this_suite->tests[i].name = _strdup(token);\
+        _this_suite->tests[i].name = token;\
         _this_suite->tests[i].funct = (*func_ptr[i]);\
     }\
-    free(functs_as_str);\
 }
 
 /* 

--- a/clove.h
+++ b/clove.h
@@ -31,6 +31,8 @@ int strncpy_s(char *strDest, size_t numberOfElements, const char *strSource, siz
 int strcpy_s(char *dest, size_t dest_size, const char *src) {
     return strcpy(dest, src) == NULL;
 }
+
+#define _strdup strdup
 #endif
 
 typedef struct __clove_test_t {
@@ -311,6 +313,7 @@ static void __clove_exec_suite(__clove_suite_t *suite, int test_counter, unsigne
 
         char result[__CLOVE_STRING_LENGTH], strToPad[__CLOVE_TEST_ENTRY_LENGTH];
         snprintf(strToPad, __CLOVE_TEST_ENTRY_LENGTH, "%d) %s.%s", test_counter+i, suite->name, each_test->name);
+	free(each_test->name); // we can safely free here
         __clove_pad_right(result, strToPad);
 
         switch(each_test->result) {
@@ -513,7 +516,7 @@ void title(__clove_suite_t *_this_suite) { \
         char *token;\
         if (i==0) { token = strtok_s(functs_as_str, ", ", &context); }\
         else { token = strtok_s(NULL, ", ", &context); }\
-        _this_suite->tests[i].name = token;\
+        _this_suite->tests[i].name = _strdup(token);\
         _this_suite->tests[i].funct = (*func_ptr[i]);\
     }\
     free(functs_as_str);\


### PR DESCRIPTION
Fixed a bug introduced by the strdup/free usage. Now a heap copy of each test name is made and freed after the reporting. The patch includes linux fixes too.