### PR TITLE
Update windows_msvc in ci_action.yml

### DIFF
--- a/.github/workflows/ci_action.yml
+++ b/.github/workflows/ci_action.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           cd ${{env.BUILD_DIR}}
           ctest -C Release -T test --output-on-failure
+          IF %ERRORLEVEL% NEQ 0 (
+            exit /b %ERRORLEVEL%
+          )
           cd ${{ github.workspace }}
   build_macos:
     name: Build macos_apple-clang


### PR DESCRIPTION
Currently, in cases where CTest encounters errors from tests, the windows_msvc job fails to register this, as shown in the screenshot provided. To fix this, I have implemented a simple validation that checks the error code and terminates the job accordingly. This would ensure consistency with other jobs that already terminate on failed tests as intended.

Screenshot:
![image](https://github.com/fdefelici/clove-unit/assets/55744345/6ff8f1c5-ec69-4cde-ad79-95d5f60f5503)
