### PR TITLE
Make header library available for CMake's FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,26 @@ add_subdirectory(tests/perfs)
 endif()
 ]]
 
-if (CLOVE_CMAKE__UC_BUILD)
-  add_subdirectory(tests/functs)
-  add_subdirectory(tests/stricts/clove-c)
-  add_subdirectory(tests/stricts/clove-cpp)
-  add_subdirectory(examples/clove101)
-  add_subdirectory(examples/clovepp)
-endif()
+#[[ 
+  In case this is the root project add dev targets.
+  To avoid targets pollution when using FetchContent were only the target library is required
+]] 
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
-if (CLOVE_CMAKE__UC_SANITY)
-  add_subdirectory(tests/stricts/clove-sanity)
-endif()
+  if (CLOVE_CMAKE__UC_BUILD)
+    add_subdirectory(tests/functs)
+    add_subdirectory(tests/stricts/clove-c)
+    add_subdirectory(tests/stricts/clove-cpp)
+    add_subdirectory(examples/clove101)
+    add_subdirectory(examples/clovepp)
+  endif()
 
-if (CLOVE_CMAKE__UC_PERFS)
-  add_subdirectory(tests/perfs)
+  if (CLOVE_CMAKE__UC_SANITY)
+    add_subdirectory(tests/stricts/clove-sanity)
+  endif()
+
+  if (CLOVE_CMAKE__UC_PERFS)
+    add_subdirectory(tests/perfs)
+  endif()
+
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
 project(CLoveUnit LANGUAGES C)
-include(CTest)
 
 add_library(clove-unit INTERFACE)
 target_include_directories(clove-unit INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
@@ -25,6 +24,7 @@ endif()
   To avoid targets pollution when using FetchContent were only the target library is required
 ]] 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  include(CTest)
 
   if (CLOVE_CMAKE__UC_BUILD)
     add_subdirectory(tests/functs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.18)
 project(CLoveUnit LANGUAGES C)
 include(CTest)
 
-add_library(CloveUnit INTERFACE)
-target_include_directories(CloveUnit INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
+add_library(clove-unit INTERFACE)
+target_include_directories(clove-unit INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
 
 #[[
 add_subdirectory(tests/functs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.18)
 project(CLoveUnit LANGUAGES C)
 include(CTest)
 
+add_library(CloveUnit INTERFACE)
+target_include_directories(CloveUnit INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
+
 #[[
 add_subdirectory(tests/functs)
 if (DEFINED CLOVE_CMAKE__CI_TRIGGERED)
@@ -17,17 +20,17 @@ endif()
 ]]
 
 if (CLOVE_CMAKE__UC_BUILD)
-    add_subdirectory(tests/functs)
-    add_subdirectory(tests/stricts/clove-c)
-    add_subdirectory(tests/stricts/clove-cpp)
-    add_subdirectory(examples/clove101)
-    add_subdirectory(examples/clovepp)
+  add_subdirectory(tests/functs)
+  add_subdirectory(tests/stricts/clove-c)
+  add_subdirectory(tests/stricts/clove-cpp)
+  add_subdirectory(examples/clove101)
+  add_subdirectory(examples/clovepp)
 endif()
 
 if (CLOVE_CMAKE__UC_SANITY)
-    add_subdirectory(tests/stricts/clove-sanity)
+  add_subdirectory(tests/stricts/clove-sanity)
 endif()
 
 if (CLOVE_CMAKE__UC_PERFS)
-    add_subdirectory(tests/perfs)
+  add_subdirectory(tests/perfs)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ include(CTest)
 
 add_library(clove-unit INTERFACE)
 target_include_directories(clove-unit INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
+target_compile_features(clove-unit INTERFACE c_std_11)
 
 #[[
 add_subdirectory(tests/functs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 ]]
 
 #[[ 
-  In case this is the root project add dev targets.
+  In case this is the root project add dev targets (Development mode).
   To avoid targets pollution when using FetchContent were only the target library is required
 ]] 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Consider also supporting `CLove-Unit` development becoming a [**sponsor**](https
 
 * [Features](#features)
 * [IDE Extensions](#ide-extensions)
-* [Supported Package Managers](#supported-package-managers)
+* [How to Integrate](#how-to-integrate)
 * [How It Works](#how-it-works)
 * [Getting Started](#getting-started)
 * [Programming API](#programming-api)
@@ -48,11 +48,65 @@ For those who prefer a UI oriented test executor, `CLove-Unit` is supported on t
 
 Have a look and enjoy ;-)
 
-## Supported Package Managers
+## How to Integrate
 
-`CLove-Unit` is also available on the following Package Managers:
+`CLove-Unit` can be imported in your project in the following ways:
+- Sourcing the header file
+- Using a Package Manager
+- Using CMake 
 
-* [Conan](https://conan.io/center/recipes/clove-unit)
+### Sourcing the Header file
+Being an header-only library, you can just download [clove-unit.h](./clove-unit.h) file and include it in your project.
+
+```c
+#include "clove-unit.h"
+```
+
+Then remember to properly configure your compiler include paths.
+
+### Using a Package Manager
+`CLove-Unit` is currently available on the following Package Managers:
+
+* [Conan](https://conan.io): read [here](https://conan.io/center/recipes/clove-unit) for details on how to import it.
+
+### Using CMake 
+In case you still need dependency management, but you want to avoid Package Manager configuration complexity, you can use standard mechansim provided by `CMake` such as [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) and [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html).
+
+> CMake library is named `clove-unit`
+
+Here a few examples:
+
+* **FetchContent**
+
+  ```cmake
+  cmake_minimum_required(VERSION 3.18)
+  project(TestProject C)
+
+  Include(FetchContent)
+  FetchContent_Declare(
+    clove-unit
+    GIT_REPOSITORY https://github.com/fdefelici/clove-unit.git
+    GIT_TAG master       # or eventually any branch, tag or commit sha
+  )
+  FetchContent_MakeAvailable(clove-unit)
+
+  add_executable(tests <YOUR_TEST_FILES>)
+  target_link_libraries(tests clove-unit)
+  ```
+
+* [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html)
+
+  First download `CLove-Unit` repository and then point properly to it like this:
+
+  ```cmake
+  cmake_minimum_required(VERSION 3.18)
+  project(TestProject C)
+
+  add_subdirectory(<PATH_TO_CLOVE_UNIT_REPOSITORY>)  
+
+  add_executable(tests <YOUR_TEST_FILES>)
+  target_link_libraries(tests clove-unit)
+  ```
 
 ## How It Works
 


### PR DESCRIPTION
Now the header library is available using `FetchContent`, for example:

```cmake
cmake_minimum_required(VERSION 3.28)
project(blah LANGUAGES C)

set(CMAKE_C_STANDARD 11)
set(CMAKE_C_STANDARD_REQUIRED YES)

Include(FetchContent)
FetchContent_Declare(
  CloveUnit
  GIT_REPOSITORY https://github.com/fdefelici/clove-unit.git
  GIT_TAG v2.4.5
)
FetchContent_MakeAvailable(CloveUnit)

add_executable(all_tests all_tests.c test_suite1.c)
target_link_libraries(all_tests PRIVATE CloveUnit)
```