### PR TITLE
Prevent MSVC warning C26451: Arithmetic overflow for clove-unit.h

### DIFF
--- a/clove-unit.h
+++ b/clove-unit.h
@@ -982,7 +982,7 @@ char* __clove_path_basepath(const char* path) {
         result = __clove_string_strdup(dot_path);
     } else {
         // Calculate base path length based on the position of the last path separator.
-        size_t base_length = (size_t)(last_char_index + 1);
+        size_t base_length = ((size_t)last_char_index) + 1;
         char* base_path = __CLOVE_MEMORY_CALLOC_TYPE_N(char, base_length);
         __clove_string_strncpy(base_path, base_length, temp_path, base_length - 1);
         __clove_path_to_os(base_path);


### PR DESCRIPTION
MSVC will report, when static analyzer warnings are enabled:
`C26451: Arithmetic overflow: Using operator '+' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '+' to avoid overflow (io.2).
`

As last_char_index + 1 fits normally in an int, there is no risk to overflow, but the warning is annoying. Fix the warning by first doing the cast and then adding 1.